### PR TITLE
Kill seeds.rb files that are no longer required

### DIFF
--- a/crowbar_engine/barclamp_ceph/db/seeds.rb
+++ b/crowbar_engine/barclamp_ceph/db/seeds.rb
@@ -1,3 +1,0 @@
-source_path = File.expand_path(File.join(__FILE__,"../../../.."))
-yml_blob = YAML.load_file(File.join(source_path,"crowbar.yml"))
-Barclamp.import("ceph",yml_blob,source_path)


### PR DESCRIPTION
This fixes the Ceph barclamp to match the changes in https://github.com/opencrowbar/core/pull/637